### PR TITLE
重构代码, 简化核心接口

### DIFF
--- a/CoreLibrary/src/main/java/com/didi/virtualapk/PluginManager.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/PluginManager.java
@@ -187,6 +187,15 @@ public class PluginManager {
 
     /**
      * load a plugin into memory, then invoke it's Application.
+     * @param apkPath the path of plugin, should end with .apk
+     * @throws Exception
+     */
+    public void loadPlugin(String apkPath) throws Exception {
+        loadPlugin(new File(apkPath));
+    }
+
+    /**
+     * load a plugin into memory, then invoke it's Application.
      * @param apk the file of plugin, should end with .apk
      * @throws Exception
      */

--- a/CoreLibrary/src/main/java/com/didi/virtualapk/PluginManager.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/PluginManager.java
@@ -31,11 +31,11 @@ import android.net.Uri;
 import android.util.Log;
 import android.util.Singleton;
 
-import com.didi.virtualapk.delegate.IContentProviderProxy;
-import com.didi.virtualapk.internal.PluginContentResolver;
 import com.didi.virtualapk.delegate.ActivityManagerProxy;
+import com.didi.virtualapk.delegate.IContentProviderProxy;
 import com.didi.virtualapk.internal.ComponentsHandler;
 import com.didi.virtualapk.internal.LoadedPlugin;
+import com.didi.virtualapk.internal.PluginContentResolver;
 import com.didi.virtualapk.internal.VAInstrumentation;
 import com.didi.virtualapk.utils.PluginUtil;
 import com.didi.virtualapk.utils.ReflectUtil;
@@ -68,34 +68,34 @@ public class PluginManager {
     private IActivityManager mActivityManager; // Hooked IActivityManager binder
     private IContentProvider mIContentProvider; // Hooked IContentProvider binder
 
-    public static PluginManager getInstance(Context base) {
+    public static PluginManager getInstance() {
         if (sInstance == null) {
             synchronized (PluginManager.class) {
                 if (sInstance == null)
-                    sInstance = new PluginManager(base);
+                    sInstance = new PluginManager();
             }
         }
 
         return sInstance;
     }
 
-    private PluginManager(Context context) {
+    private PluginManager() {}
+
+    /**
+     * initialize the Plugin Manager, You must call this is method before you use this framework !
+     * @param context
+     */
+    public void init(Context context) {
         Context app = context.getApplicationContext();
         if (app == null) {
             this.mContext = context;
         } else {
             this.mContext = ((Application)app).getBaseContext();
         }
-        prepare();
-    }
-
-    private void prepare() {
         Systems.sHostContext = getHostContext();
         this.hookInstrumentationAndHandler();
         this.hookSystemServices();
-    }
 
-    public void init() {
         mComponentsHandler = new ComponentsHandler(this);
         RunUtil.getThreadPool().execute(new Runnable() {
             @Override

--- a/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/IContentProviderProxy.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/IContentProviderProxy.java
@@ -95,7 +95,7 @@ public class IContentProviderProxy implements InvocationHandler {
             return;
         }
 
-        PluginManager pluginManager = PluginManager.getInstance(mContext);
+        PluginManager pluginManager = PluginManager.getInstance();
         ProviderInfo info = pluginManager.resolveContentProvider(uri.getAuthority(), 0);
         if (info != null) {
             String pkg = info.packageName;

--- a/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/LocalService.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/LocalService.java
@@ -65,7 +65,7 @@ public class LocalService extends Service {
     @Override
     public void onCreate() {
         super.onCreate();
-        mPluginManager = PluginManager.getInstance(this);
+        mPluginManager = PluginManager.getInstance();
     }
 
     @Override

--- a/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/RemoteContentProvider.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/RemoteContentProvider.java
@@ -20,7 +20,6 @@ import android.content.ContentProvider;
 import android.content.ContentProviderOperation;
 import android.content.ContentProviderResult;
 import android.content.ContentValues;
-import android.content.Context;
 import android.content.OperationApplicationException;
 import android.content.pm.ProviderInfo;
 import android.database.Cursor;
@@ -62,7 +61,7 @@ public class RemoteContentProvider extends ContentProvider {
     }
 
     private ContentProvider getContentProvider(final Uri uri) {
-        final PluginManager pluginManager = PluginManager.getInstance(getContext());
+        final PluginManager pluginManager = PluginManager.getInstance();
         Uri pluginUri = Uri.parse(uri.getQueryParameter(KEY_URI));
         final String auth = pluginUri.getAuthority();
         ContentProvider cachedProvider = sCachedProviders.get(auth);

--- a/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/RemoteContentProvider.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/RemoteContentProvider.java
@@ -32,7 +32,6 @@ import com.didi.virtualapk.PluginManager;
 import com.didi.virtualapk.internal.LoadedPlugin;
 import com.didi.virtualapk.utils.RunUtil;
 
-import java.io.File;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -73,7 +72,7 @@ public class RemoteContentProvider extends ContentProvider {
             LoadedPlugin plugin = pluginManager.getLoadedPlugin(uri.getQueryParameter(KEY_PKG));
             if (plugin == null) {
                 try {
-                    pluginManager.loadPlugin(new File(uri.getQueryParameter(KEY_PLUGIN)));
+                    pluginManager.loadPlugin(uri.getQueryParameter(KEY_PLUGIN));
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/RemoteService.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/RemoteService.java
@@ -19,11 +19,10 @@ package com.didi.virtualapk.delegate;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.os.IBinder;
+import android.text.TextUtils;
 
 import com.didi.virtualapk.PluginManager;
 import com.didi.virtualapk.internal.LoadedPlugin;
-
-import java.io.File;
 
 /**
  * @author johnsonlee
@@ -43,12 +42,12 @@ public class RemoteService extends LocalService {
 
         Intent target = intent.getParcelableExtra(EXTRA_TARGET);
         if (target != null) {
-            String pluginLocation = intent.getStringExtra(EXTRA_PLUGIN_LOCATION);
+            String pluginPath = intent.getStringExtra(EXTRA_PLUGIN_LOCATION);
             ComponentName component = target.getComponent();
             LoadedPlugin plugin = PluginManager.getInstance().getLoadedPlugin(component);
-            if (plugin == null && pluginLocation != null) {
+            if (plugin == null && !TextUtils.isEmpty(pluginPath)) {
                 try {
-                    PluginManager.getInstance().loadPlugin(new File(pluginLocation));
+                    PluginManager.getInstance().loadPlugin(pluginPath);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/RemoteService.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/RemoteService.java
@@ -45,10 +45,10 @@ public class RemoteService extends LocalService {
         if (target != null) {
             String pluginLocation = intent.getStringExtra(EXTRA_PLUGIN_LOCATION);
             ComponentName component = target.getComponent();
-            LoadedPlugin plugin = PluginManager.getInstance(this).getLoadedPlugin(component);
+            LoadedPlugin plugin = PluginManager.getInstance().getLoadedPlugin(component);
             if (plugin == null && pluginLocation != null) {
                 try {
-                    PluginManager.getInstance(this).loadPlugin(new File(pluginLocation));
+                    PluginManager.getInstance().loadPlugin(new File(pluginLocation));
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/CoreLibrary/src/main/java/com/didi/virtualapk/internal/PluginContentResolver.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/internal/PluginContentResolver.java
@@ -58,7 +58,7 @@ public class PluginContentResolver extends ContentResolver {
     public PluginContentResolver(Context context) {
         super(context);
         mBase = context.getContentResolver();
-        mPluginManager = PluginManager.getInstance(context);
+        mPluginManager = PluginManager.getInstance();
     }
 
     protected IContentProvider acquireProvider(Context context, String auth) {

--- a/CoreLibrary/src/main/java/com/didi/virtualapk/internal/ResourcesManager.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/internal/ResourcesManager.java
@@ -47,7 +47,7 @@ class ResourcesManager {
                 assetManager = hostResources.getAssets();
             }
             ReflectUtil.invoke(AssetManager.class, assetManager, "addAssetPath", apk);
-            List<LoadedPlugin> pluginList = PluginManager.getInstance(hostContext).getAllLoadedPlugins();
+            List<LoadedPlugin> pluginList = PluginManager.getInstance().getAllLoadedPlugins();
             for (LoadedPlugin plugin : pluginList) {
                 ReflectUtil.invoke(AssetManager.class, assetManager, "addAssetPath", plugin.getLocation());
             }

--- a/CoreLibrary/src/main/java/com/didi/virtualapk/utils/PluginUtil.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/utils/PluginUtil.java
@@ -23,14 +23,11 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 import android.content.pm.ServiceInfo;
-import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.support.annotation.Keep;
 import android.text.TextUtils;
 import android.view.ContextThemeWrapper;
 
@@ -46,10 +43,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -76,7 +69,7 @@ public class PluginUtil {
     }
 
     public static int getTheme(Context context, ComponentName component) {
-        LoadedPlugin loadedPlugin = PluginManager.getInstance(context).getLoadedPlugin(component);
+        LoadedPlugin loadedPlugin = PluginManager.getInstance().getLoadedPlugin(component);
 
         if (null == loadedPlugin) {
             return 0;
@@ -136,7 +129,7 @@ public class PluginUtil {
         // designed for 5.0 - only, but some bad phones not work, eg:letv
         try {
             Context base = activity.getBaseContext();
-            final LoadedPlugin plugin = PluginManager.getInstance(activity).getLoadedPlugin(packageName);
+            final LoadedPlugin plugin = PluginManager.getInstance().getLoadedPlugin(packageName);
             final Resources resources = plugin.getResources();
             if (resources != null) {
                 ReflectUtil.setField(base.getClass(), base, "mResources", resources);

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Initialize `PluginManager` in `YourApplication::attachBaseContext()`.
 @Override
 protected void attachBaseContext(Context base) {
     super.attachBaseContext(base);
-    PluginManager.getInstance(base).init();
+    PluginManager.getInstance().init(base);
 }
 ```
 
@@ -69,8 +69,7 @@ Finally, load an APK and have fun!
 
 ``` java
 String pluginPath = Environment.getExternalStorageDirectory().getAbsolutePath().concat("/Test.apk");
-File plugin = new File(pluginPath);
-PluginManager.getInstance(base).loadPlugin(plugin);
+PluginManager.getInstance().loadPlugin(pluginPath);
 
 // Given "com.didi.virtualapk.demo" is the package name of plugin APK, 
 // and there is an activity called `MainActivity`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,8 +45,8 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
 
-    compile 'com.didi.virtualapk:core:0.9.0'
+//    compile 'com.didi.virtualapk:core:0.9.0'
 
-    //compile project (":CoreLibrary")
+    compile project (":CoreLibrary")
 
 }

--- a/app/src/main/java/com/didi/virtualapk/MainActivity.java
+++ b/app/src/main/java/com/didi/virtualapk/MainActivity.java
@@ -70,15 +70,12 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void loadPlugin(Context base) {
-        PluginManager pluginManager = PluginManager.getInstance();
-        File apk = new File(Environment.getExternalStorageDirectory(), "Test.apk");
-        if (apk.exists()) {
             try {
-                pluginManager.loadPlugin(apk);
+                String apkPath = Environment.getExternalStorageDirectory() + File.separator +  "Test.apk" ;
+                PluginManager.getInstance().loadPlugin(apkPath);
             } catch (Exception e) {
                 e.printStackTrace();
             }
-        }
     }
 
     private void showAbout() {

--- a/app/src/main/java/com/didi/virtualapk/MainActivity.java
+++ b/app/src/main/java/com/didi/virtualapk/MainActivity.java
@@ -42,7 +42,7 @@ public class MainActivity extends AppCompatActivity {
     public void onButtonClick(View v) {
         if (v.getId() == R.id.button) {
             final String pkg = "com.didi.virtualapk.demo";
-            if (PluginManager.getInstance(this).getLoadedPlugin(pkg) == null) {
+            if (PluginManager.getInstance().getLoadedPlugin(pkg) == null) {
                 Toast.makeText(this, "plugin [com.didi.virtualapk.demo] not loaded", Toast.LENGTH_SHORT).show();
                 return;
             }
@@ -54,7 +54,7 @@ public class MainActivity extends AppCompatActivity {
 
             // test ContentProvider
             Uri bookUri = Uri.parse("content://com.didi.virtualapk.demo.book.provider/book");
-            LoadedPlugin plugin = PluginManager.getInstance(this).getLoadedPlugin(pkg);
+            LoadedPlugin plugin = PluginManager.getInstance().getLoadedPlugin(pkg);
             bookUri = PluginContentResolver.wrapperUri(plugin, bookUri);
 
             Cursor bookCursor = getContentResolver().query(bookUri, new String[]{"_id", "name"}, null, null, null);
@@ -70,7 +70,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void loadPlugin(Context base) {
-        PluginManager pluginManager = PluginManager.getInstance(base);
+        PluginManager pluginManager = PluginManager.getInstance();
         File apk = new File(Environment.getExternalStorageDirectory(), "Test.apk");
         if (apk.exists()) {
             try {

--- a/app/src/main/java/com/didi/virtualapk/VAApplication.java
+++ b/app/src/main/java/com/didi/virtualapk/VAApplication.java
@@ -13,7 +13,7 @@ public class VAApplication extends Application {
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(base);
         long start = System.currentTimeMillis();
-        PluginManager.getInstance(base).init();
+        PluginManager.getInstance().init(base);
         Log.d("ryg", "use time:" + (System.currentTimeMillis() - start));
     }
 


### PR DESCRIPTION
1. 将 `getInstance(Context ctx)`的Context参数移到init()函数中, 避免用户每次调用 getInstance 都需要传递Context
2. 添加` loadPlugin(String apkPath)` 接口, 避免用户加载插件时都需要构造 File 对象

看到readme中出现的 这两个接口不太合适，空闲之余重构了这两个地方，其他代码还未看，管理员 review 是否能够 merge . 