### PR TITLE
fix: read defaultCpuArch defined in metaData to copy specific cpu arch

### DIFF
--- a/CoreLibrary/src/main/java/com/didi/virtualapk/internal/LoadedPlugin.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/internal/LoadedPlugin.java
@@ -225,7 +225,14 @@ public final class LoadedPlugin {
     private void tryToCopyNativeLib(File apk) {
         Bundle metaData = this.mPackageInfo.applicationInfo.metaData;
         if (metaData != null && metaData.getBoolean("VA_IS_HAVE_LIB")) {
-            PluginUtil.copyNativeLib(apk, mHostContext, mPackageInfo, mNativeLibDir);
+            String cpuArch;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                cpuArch = Build.SUPPORTED_ABIS[0];
+            } else {
+                cpuArch = Build.CPU_ABI;
+            }
+            String defaultArch = metaData.getString("VA_DEFAULT_CPU_ARCH", cpuArch);
+            PluginUtil.copyNativeLib(apk, defaultArch, mHostContext, mPackageInfo, mNativeLibDir);
         }
     }
 

--- a/CoreLibrary/src/main/java/com/didi/virtualapk/utils/PluginUtil.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/utils/PluginUtil.java
@@ -187,14 +187,8 @@ public class PluginUtil {
         }
     }
 
-    public static void copyNativeLib(File apk, Context context, PackageInfo packageInfo, File nativeLibDir) {
+    public static void copyNativeLib(File apk, String cpuArch, Context context, PackageInfo packageInfo, File nativeLibDir) {
         try {
-            String cpuArch;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                cpuArch = Build.SUPPORTED_ABIS[0];
-            } else {
-                cpuArch = Build.CPU_ABI;
-            }
             boolean findSo = false;
 
             ZipFile zipfile = new ZipFile(apk.getAbsolutePath());


### PR DESCRIPTION
CopyNativeLib method only copy current device cpu arch or fallback to armeabi.
if plugin apk only contains armeabi-v7a and device support_abi is not armeabi-v7a,  nothing would be copied.
So we can specify default cpu arch to tell PluginLoader copy right cpu arch.