### PR TITLE
 fix the bug 'ClassNotFoundException when unmarshalling' in Android 5.1

### DIFF
--- a/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/LocalService.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/delegate/LocalService.java
@@ -83,7 +83,8 @@ public class LocalService extends Service {
 
         ComponentName component = target.getComponent();
         LoadedPlugin plugin = mPluginManager.getLoadedPlugin(component);
-
+        // ClassNotFoundException when unmarshalling in Android 5.1
+        target.setExtrasClassLoader(plugin.getClassLoader());
         switch (command) {
             case EXTRA_COMMAND_START_SERVICE: {
                 ActivityThread mainThread = (ActivityThread)ReflectUtil.getActivityThread(getBaseContext());


### PR DESCRIPTION
在当前进程中启动插件中的service时候，通过intent传递自定义对象。
该操作在 Android 5.1版本会ClassNotFoundException when unmarshalling

@singwhatiwanna 重新提了