### PR TITLE
Fixed "Activity not found exception" with arabic language.

### DIFF
--- a/CoreLibrary/src/main/java/com/didi/virtualapk/internal/StubActivityInfo.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/internal/StubActivityInfo.java
@@ -22,6 +22,7 @@ import android.util.Log;
 import android.content.res.Resources.Theme;
 
 import java.util.HashMap;
+import java.util.Locale;
 
 /**
  * Created by renyugang on 16/8/15.
@@ -60,28 +61,28 @@ class StubActivityInfo {
         if (Constants.DEBUG) {
             Log.d(Constants.TAG_PREFIX + "StubActivityInfo", "getStubActivity, is transparent theme ? " + windowIsTranslucent);
         }
-        stubActivity = String.format(STUB_ACTIVITY_STANDARD, corePackage, usedStandardStubActivity);
+        stubActivity = String.format(Locale.US, STUB_ACTIVITY_STANDARD, corePackage, usedStandardStubActivity);
         switch (launchMode) {
             case ActivityInfo.LAUNCH_MULTIPLE: {
-                stubActivity = String.format(STUB_ACTIVITY_STANDARD, corePackage, usedStandardStubActivity);
+                stubActivity = String.format(Locale.US, STUB_ACTIVITY_STANDARD, corePackage, usedStandardStubActivity);
                 if (windowIsTranslucent) {
-                    stubActivity = String.format(STUB_ACTIVITY_STANDARD, corePackage, 2);
+                    stubActivity = String.format(Locale.US, STUB_ACTIVITY_STANDARD, corePackage, 2);
                 }
                 break;
             }
             case ActivityInfo.LAUNCH_SINGLE_TOP: {
                 usedSingleTopStubActivity = usedSingleTopStubActivity % MAX_COUNT_SINGLETOP + 1;
-                stubActivity = String.format(STUB_ACTIVITY_SINGLETOP, corePackage, usedSingleTopStubActivity);
+                stubActivity = String.format(Locale.US, STUB_ACTIVITY_SINGLETOP, corePackage, usedSingleTopStubActivity);
                 break;
             }
             case ActivityInfo.LAUNCH_SINGLE_TASK: {
                 usedSingleTaskStubActivity = usedSingleTaskStubActivity % MAX_COUNT_SINGLETASK + 1;
-                stubActivity = String.format(STUB_ACTIVITY_SINGLETASK, corePackage, usedSingleTaskStubActivity);
+                stubActivity = String.format(Locale.US, STUB_ACTIVITY_SINGLETASK, corePackage, usedSingleTaskStubActivity);
                 break;
             }
             case ActivityInfo.LAUNCH_SINGLE_INSTANCE: {
                 usedSingleInstanceStubActivity = usedSingleInstanceStubActivity % MAX_COUNT_SINGLEINSTANCE + 1;
-                stubActivity = String.format(STUB_ACTIVITY_SINGLEINSTANCE, corePackage, usedSingleInstanceStubActivity);
+                stubActivity = String.format(Locale.US, STUB_ACTIVITY_SINGLEINSTANCE, corePackage, usedSingleInstanceStubActivity);
                 break;
             }
 


### PR DESCRIPTION
"Activity not found exception" occurs when using the arabic locale in the app.
The reason is that "String.format (STUB_ACTIVITY_STANDARD, corePackage, usedStandardStubActivity)" results in ".A$١"(arabic 1).