### PR TITLE
支持插件动态向宿主申请权限

### DIFF
--- a/CoreLibrary/src/main/java/com/didi/virtualapk/internal/LoadedPlugin.java
+++ b/CoreLibrary/src/main/java/com/didi/virtualapk/internal/LoadedPlugin.java
@@ -521,6 +521,15 @@ public class LoadedPlugin {
 
         protected PackageManager mHostPackageManager = mHostContext.getPackageManager();
 
+        public Intent buildRequestPermissionsIntent(@NonNull String[] permissions) {
+            try {
+                return Reflector.on(PackageManager.class).bind(mHostPackageManager).method("buildRequestPermissionsIntent", String[].class).call((Object)permissions);
+            } catch (Reflector.ReflectedException e) {
+                e.printStackTrace();
+            }
+            return null;
+        }
+    
         @Override
         public PackageInfo getPackageInfo(String packageName, int flags) throws NameNotFoundException {
 


### PR DESCRIPTION
修复申请权限时出现java.lang.AbstractMethodError: abstract method "java.lang.String android.content.pm.PackageManager.getPermissionControllerPackageName()"异常